### PR TITLE
Resolve shellcheck warnings

### DIFF
--- a/query_ucla_noc_ips
+++ b/query_ucla_noc_ips
@@ -5,7 +5,7 @@ ACTION='null'
 DEPT_ID='null'
 
 function USAGE() {
-  echo -e "\nUsage: `basename $0` [ -l | -d [DEPARTMENT_ID] ]"
+  echo -e "\nUsage: $(basename "$0") [ -l | -d [DEPARTMENT_ID] ]"
   echo -e "-l         --> List all departments and associated IDs"
   echo -e "-d ID      --> Query department networks by ID"
 }


### PR DESCRIPTION
- SC2006 (style): Use $(...) notation instead of legacy backticks `...`.
- SC2086 (info): Double quote to prevent globbing and word splitting.